### PR TITLE
Last.fm scrobbler

### DIFF
--- a/WhatManager2/settings.example.py
+++ b/WhatManager2/settings.example.py
@@ -67,6 +67,15 @@ FILES_SYNC_HTTP_PASSWORD = 'password'
 FILES_SYNC_SSH = 'user@host.com'
 FILES_SYNC_WM_ROOT = 'https://host.com/'
 
+# You only need to set these if you want to scrobble to last.fm
+# You have to have your own unique two values for API_KEY and API_SECRET
+# Obtain yours from http://www.last.fm/api/account for Last.fm
+LASTFM_API_KEY = '' # Create your own api key
+LASTFM_API_SECRET = '' 
+LASTFM_USERNAME = '' # Your lastfm username
+LASTFM_PASSWORD = '' # Your lastfm password
+
+
 # Used permissions
 # home_view_logentry - Viewing logs
 # home_add_whattorrent - Adding torrents

--- a/WhatManager2/settings.example.py
+++ b/WhatManager2/settings.example.py
@@ -70,10 +70,10 @@ FILES_SYNC_WM_ROOT = 'https://host.com/'
 # You only need to set these if you want to scrobble to last.fm
 # You have to have your own unique two values for API_KEY and API_SECRET
 # Obtain yours from http://www.last.fm/api/account for Last.fm
-LASTFM_API_KEY = '' # Create your own api key
-LASTFM_API_SECRET = '' 
-LASTFM_USERNAME = '' # Your lastfm username
-LASTFM_PASSWORD = '' # Your lastfm password
+LASTFM_API_KEY = ''  # Create your own api key
+LASTFM_API_SECRET = ''
+LASTFM_USERNAME = ''  # Your lastfm username
+LASTFM_PASSWORD = ''  # Your lastfm password
 
 
 # Used permissions

--- a/WhatManager2/urls.py
+++ b/WhatManager2/urls.py
@@ -20,5 +20,5 @@ urlpatterns = patterns(
     url(r'^userscript/', include('userscript.urls')),
     url(r'^what_meta/', include('what_meta.urls')),
     url(r'^whatify/', include('whatify.urls')),
-    url(r'^lastfm/scrobbler$', 'lastfm.views.scrobble'),
+    url(r'^lastfm/scrobbler/', 'lastfm.views.scrobble'),
 )

--- a/WhatManager2/urls.py
+++ b/WhatManager2/urls.py
@@ -20,5 +20,5 @@ urlpatterns = patterns(
     url(r'^userscript/', include('userscript.urls')),
     url(r'^what_meta/', include('what_meta.urls')),
     url(r'^whatify/', include('whatify.urls')),
-    url(r'^lastfm/scrobbler/', 'lastfm.views.scrobble'),
+    url(r'^lastfm/scrobble/', 'lastfm.views.scrobble'),
 )

--- a/WhatManager2/urls.py
+++ b/WhatManager2/urls.py
@@ -20,4 +20,5 @@ urlpatterns = patterns(
     url(r'^userscript/', include('userscript.urls')),
     url(r'^what_meta/', include('what_meta.urls')),
     url(r'^whatify/', include('whatify.urls')),
+    url(r'^lastfm/scrobbler$', 'lastfm.views.scrobble'),
 )

--- a/lastfm/settings.example.py
+++ b/lastfm/settings.example.py
@@ -1,0 +1,4 @@
+API_KEY = '' # Create your own api key
+API_SECRET = '' 
+LASTFM_USERNAME = '' # Your lastfm username
+LASTFM_PASSWORD = '' # Your lastfm password

--- a/lastfm/settings.example.py
+++ b/lastfm/settings.example.py
@@ -1,4 +1,0 @@
-API_KEY = '' # Create your own api key
-API_SECRET = '' 
-LASTFM_USERNAME = '' # Your lastfm username
-LASTFM_PASSWORD = '' # Your lastfm password

--- a/lastfm/views.py
+++ b/lastfm/views.py
@@ -5,13 +5,11 @@ from django.http import StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
 import pylast
 import time 
-
-# You have to have your own unique two values for API_KEY and API_SECRET
-# Obtain yours from http://www.last.fm/api/account for Last.fm
+import from WhatManager2.settings LASTFM_API_KEY, LASTFM_API_SECRET, LASTFM_USERNAME, LASTFM_PASSWORD
 
 
-lastfm_network = pylast.LastFMNetwork(api_key = API_KEY, api_secret =
-    API_SECRET, username = username, password_hash = password_hash)
+lastfm_network = pylast.LastFMNetwork(api_key = LASTFM_API_KEY, api_secret =
+    LASTFM_API_SECRET, username = LASTFM_USERNAME, password_hash = pylast.md5(LASTFM_PASSWORD))
 
 
 @csrf_exempt

--- a/lastfm/views.py
+++ b/lastfm/views.py
@@ -6,7 +6,7 @@ import time
 from WhatManager2.settings import LASTFM_API_KEY, LASTFM_API_SECRET, \
     LASTFM_USERNAME, LASTFM_PASSWORD
 
-if "" not in (LASTFM_API_KEY, LASTFM_API_SECRET, LASTFM_USERNAME, LASTFM_PASSWORD):
+if all(LASTFM_API_KEY, LASTFM_API_SECRET, LASTFM_USERNAME, LASTFM_PASSWORD):
     lastfm_network = pylast.LastFMNetwork(api_key=LASTFM_API_KEY,
                                           api_secret=LASTFM_API_SECRET,
                                           username=LASTFM_USERNAME,

--- a/lastfm/views.py
+++ b/lastfm/views.py
@@ -6,7 +6,7 @@ import time
 from WhatManager2.settings import LASTFM_API_KEY, LASTFM_API_SECRET, \
     LASTFM_USERNAME, LASTFM_PASSWORD
 
-if all(LASTFM_API_KEY, LASTFM_API_SECRET, LASTFM_USERNAME, LASTFM_PASSWORD):
+if all([LASTFM_API_KEY, LASTFM_API_SECRET, LASTFM_USERNAME, LASTFM_PASSWORD]):
     lastfm_network = pylast.LastFMNetwork(api_key=LASTFM_API_KEY,
                                           api_secret=LASTFM_API_SECRET,
                                           username=LASTFM_USERNAME,

--- a/lastfm/views.py
+++ b/lastfm/views.py
@@ -1,0 +1,29 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+import json
+from django.http import StreamingHttpResponse
+from django.views.decorators.csrf import csrf_exempt
+import pylast
+import time 
+
+# You have to have your own unique two values for API_KEY and API_SECRET
+# Obtain yours from http://www.last.fm/api/account for Last.fm
+
+
+lastfm_network = pylast.LastFMNetwork(api_key = API_KEY, api_secret =
+    API_SECRET, username = username, password_hash = password_hash)
+
+
+@csrf_exempt
+def scrobble(request):
+    print 'Request'
+    print vars(request)
+    if request.method=='POST':
+            received_json_data=json.loads(request.body)
+            artist = received_json_data['artist']
+            song = received_json_data['title']
+            lastfm_network.scrobble(
+            artist=artist, title=song, timestamp=int(time.time()))
+            #received_json_data=json.loads(request.body)
+            return StreamingHttpResponse('it was post request: '+str(received_json_data))
+    return StreamingHttpResponse('it was GET request')

--- a/lastfm/views.py
+++ b/lastfm/views.py
@@ -16,12 +16,12 @@ else:
 
 @csrf_protect
 def scrobble(request):
-    if request.method == 'POST' and not lastfm_network:
+    if request.method == 'POST' and lastfm_network is not None:
             received_json_data = json.loads(request.body)
             artist = received_json_data['artist']
             song = received_json_data['title']
             lastfm_network.scrobble(artist=artist,
                                     title=song,
                                     timestamp=int(time.time()))
-            return StreamingHttpResponse('it was post request: '+str(received_json_data))
-    return StreamingHttpResponse('it was GET request')
+            return StreamingHttpResponse('Scrobbled')
+    return StreamingHttpResponse('Did not scrobble. It was GET request or no last.fm setup')

--- a/lastfm/views.py
+++ b/lastfm/views.py
@@ -1,27 +1,27 @@
-from django.contrib.auth.decorators import login_required
-from django.shortcuts import render
 import json
 from django.http import StreamingHttpResponse
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.csrf import csrf_protect
 import pylast
-import time 
-import from WhatManager2.settings LASTFM_API_KEY, LASTFM_API_SECRET, LASTFM_USERNAME, LASTFM_PASSWORD
+import time
+from WhatManager2.settings import LASTFM_API_KEY, LASTFM_API_SECRET, \
+    LASTFM_USERNAME, LASTFM_PASSWORD
+
+if "" not in (LASTFM_API_KEY, LASTFM_API_SECRET, LASTFM_USERNAME, LASTFM_PASSWORD):
+    lastfm_network = pylast.LastFMNetwork(api_key=LASTFM_API_KEY, api_secret=
+                                          LASTFM_API_SECRET, username=LASTFM_USERNAME,
+                                          password_hash=pylast.md5(LASTFM_PASSWORD))
+else:
+    lastfm_network = None
 
 
-lastfm_network = pylast.LastFMNetwork(api_key = LASTFM_API_KEY, api_secret =
-    LASTFM_API_SECRET, username = LASTFM_USERNAME, password_hash = pylast.md5(LASTFM_PASSWORD))
-
-
-@csrf_exempt
+@csrf_protect
 def scrobble(request):
-    print 'Request'
-    print vars(request)
-    if request.method=='POST':
-            received_json_data=json.loads(request.body)
+    if request.method == 'POST' and not lastfm_network:
+            received_json_data = json.loads(request.body)
             artist = received_json_data['artist']
             song = received_json_data['title']
-            lastfm_network.scrobble(
-            artist=artist, title=song, timestamp=int(time.time()))
-            #received_json_data=json.loads(request.body)
+            lastfm_network.scrobble(artist=artist,
+                                    title=song,
+                                    timestamp=int(time.time()))
             return StreamingHttpResponse('it was post request: '+str(received_json_data))
     return StreamingHttpResponse('it was GET request')

--- a/lastfm/views.py
+++ b/lastfm/views.py
@@ -7,8 +7,9 @@ from WhatManager2.settings import LASTFM_API_KEY, LASTFM_API_SECRET, \
     LASTFM_USERNAME, LASTFM_PASSWORD
 
 if "" not in (LASTFM_API_KEY, LASTFM_API_SECRET, LASTFM_USERNAME, LASTFM_PASSWORD):
-    lastfm_network = pylast.LastFMNetwork(api_key=LASTFM_API_KEY, api_secret=
-                                          LASTFM_API_SECRET, username=LASTFM_USERNAME,
+    lastfm_network = pylast.LastFMNetwork(api_key=LASTFM_API_KEY,
+                                          api_secret=LASTFM_API_SECRET,
+                                          username=LASTFM_USERNAME,
                                           password_hash=pylast.md5(LASTFM_PASSWORD))
 else:
     lastfm_network = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ billiard>=3.3.0.17
 django-bootstrap-form>=3.1
 sqlparse>=0.1.11
 ujson>=1.33
+pylast>=1.0.0

--- a/static/player/html5player.js
+++ b/static/player/html5player.js
@@ -99,6 +99,7 @@ function multiplayer(dgPlayer, urls) {
             API.endedCallback();
         })
         window.p = currentAurora.player;
+        scrobble(dgPlayer.songArtist,  dgPlayer.songTitle);
     }
 
     function playBuzz(url) {
@@ -114,6 +115,7 @@ function multiplayer(dgPlayer, urls) {
             }
         })
         currentBuzz.ui = new DGHTML5Player(currentBuzz.player, dgPlayer);
+        scrobble(dgPlayer.songArtist,  dgPlayer.songTitle);
     }
 
     function loadMetadata(url) {
@@ -156,4 +158,47 @@ function openPlayer(playlist) {
 
 function playWhat(whatId) {
     openPlayer('what/' + whatId);
+}
+// using jQuery
+function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie != '') {
+        var cookies = document.cookie.split(';');
+        for (var i = 0; i < cookies.length; i++) {
+            var cookie = jQuery.trim(cookies[i]);
+            // Does this cookie string begin with the name we want?
+            if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                break;
+            }
+        }
+    }
+    return cookieValue;
+}
+var csrftoken = getCookie('csrftoken');
+    function sameOrigin(url) {
+    // test that a given url is a same-origin URL
+    // url could be relative or scheme relative or absolute
+    var host = document.location.host; // host + port
+    var protocol = document.location.protocol;
+    var sr_origin = '//' + host;
+    var origin = protocol + sr_origin;
+    // Allow absolute or scheme relative URLs to same origin
+    return (url == origin || url.slice(0, origin.length + 1) == origin + '/') ||
+            (url == sr_origin || url.slice(0, sr_origin.length + 1) == sr_origin + '/') ||
+            // or any other URL that isn't scheme relative or absolute i.e relative.
+            !(/^(\/\/|http:|https:).*/.test(url));
+    }
+$.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+        if (sameOrigin(settings.url)) {
+            // Send the token to same-origin, relative URLs only.
+            // Send the token only if the method warrants CSRF protection
+            // Using the CSRFToken value acquired earlier
+            xhr.setRequestHeader("X-CSRFToken", csrftoken);
+        }
+    }
+});
+function scrobble(songArtist, songTitle) {
+    $.post( window.location.href.replace(window.location.search, '').replace('player','lastfm/scrobble'), JSON.stringify({ "artist": songArtist, "title" : songTitle}) );
 }

--- a/static/whatify/player/player.js
+++ b/static/whatify/player/player.js
@@ -202,7 +202,6 @@ angular.
             s.index = index;
             update();
             whatPlayer.load(s.currentItem.url);
-            console.log('HERE WE GOT');
             whatPlayer.play();
             $.post( window.location.href.replace(window.location.hash, '').replace('whatify','lastfm/scrobble'), JSON.stringify({ "artist": s.currentItem.metadata.artist, "title" : s.currentItem.metadata.title, "album" : s.currentItem.metadata.album }) );
         };

--- a/static/whatify/player/player.js
+++ b/static/whatify/player/player.js
@@ -162,7 +162,11 @@ angular.
             s.index = index;
             update();
             whatPlayer.load(s.currentItem.url);
+            console.log('HERE WE GOT');
             whatPlayer.play();
+                            url = window.location.href.replace(window.location.hash,
+                        '#/torrentGroups/' + torrentGroup.id) + '/play';
+            $.post( "/lastfm/scrobble", JSON.stringify({ "artist": s.currentItem.metadata.artist, "title" : s.currentItem.metadata.title, "album" : s.currentItem.metadata.album }) );
         };
         s.add = function(item) {
             s.items.push(item);

--- a/static/whatify/player/player.js
+++ b/static/whatify/player/player.js
@@ -158,6 +158,46 @@ angular.
             update();
             whatPlayer.load(null);
         };
+        // using jQuery
+        function getCookie(name) {
+            var cookieValue = null;
+            if (document.cookie && document.cookie != '') {
+                var cookies = document.cookie.split(';');
+                for (var i = 0; i < cookies.length; i++) {
+                    var cookie = jQuery.trim(cookies[i]);
+                    // Does this cookie string begin with the name we want?
+                    if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
+                }
+            }
+            return cookieValue;
+        }
+        var csrftoken = getCookie('csrftoken');
+        function sameOrigin(url) {
+            // test that a given url is a same-origin URL
+            // url could be relative or scheme relative or absolute
+            var host = document.location.host; // host + port
+            var protocol = document.location.protocol;
+            var sr_origin = '//' + host;
+            var origin = protocol + sr_origin;
+            // Allow absolute or scheme relative URLs to same origin
+            return (url == origin || url.slice(0, origin.length + 1) == origin + '/') ||
+                (url == sr_origin || url.slice(0, sr_origin.length + 1) == sr_origin + '/') ||
+                // or any other URL that isn't scheme relative or absolute i.e relative.
+                !(/^(\/\/|http:|https:).*/.test(url));
+        }
+        $.ajaxSetup({
+            beforeSend: function(xhr, settings) {
+                if (sameOrigin(settings.url)) {
+                    // Send the token to same-origin, relative URLs only.
+                    // Send the token only if the method warrants CSRF protection
+                    // Using the CSRFToken value acquired earlier
+                    xhr.setRequestHeader("X-CSRFToken", csrftoken);
+                }
+            }
+        });
         s.play = function(index) {
             s.index = index;
             update();

--- a/static/whatify/player/player.js
+++ b/static/whatify/player/player.js
@@ -164,9 +164,7 @@ angular.
             whatPlayer.load(s.currentItem.url);
             console.log('HERE WE GOT');
             whatPlayer.play();
-                            url = window.location.href.replace(window.location.hash,
-                        '#/torrentGroups/' + torrentGroup.id) + '/play';
-            $.post( "/lastfm/scrobble", JSON.stringify({ "artist": s.currentItem.metadata.artist, "title" : s.currentItem.metadata.title, "album" : s.currentItem.metadata.album }) );
+            $.post( window.location.href.replace(window.location.hash, '').replace('whatify','lastfm/scrobble'), JSON.stringify({ "artist": s.currentItem.metadata.artist, "title" : s.currentItem.metadata.title, "album" : s.currentItem.metadata.album }) );
         };
         s.add = function(item) {
             s.items.push(item);


### PR DESCRIPTION
A last.fm scrobbler. 
Uses the pylast library to easily scrobble to last.fm. Only works with whatify right now. The player (js) sends a POST to lastfm/scrobble with the data as json and the actual scrobbling occurs in a python file. 
