### PR TITLE
Fix Django dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bencode>=1.0
-Django>=1.7
+Django==1.8.9
 MySQL-python>=1.2.4
 django-celery>=3.0.23
 mutagen>=1.22


### PR DESCRIPTION
Django/Django@ec18657 removes `parse_datetime_with_timezone_support` thus the Django version must at most be `1.8.9`. This produces the following stacktrace when running `./manage.py migrate` https://sicp.me/p/kF8m2

Thanks to @clsr for helping me debug this.