### PR TITLE
Bibliotik Cookie Domain Change

### DIFF
--- a/bibliotik/models.py
+++ b/bibliotik/models.py
@@ -104,6 +104,8 @@ class BibliotikTorrent(models.Model):
             details = details[1:]
         else:
             self.pages = 0
+        if details[0] == u'Unabridged' or details[0] == u'Abridged':
+            details = details[1:]
         if details[0].split(' ')[0] in LANGUAGES:
             parts = details[0].split(' ')
             details = details[1:]

--- a/templates/userscript/BibliotikSessionStealer/background.js
+++ b/templates/userscript/BibliotikSessionStealer/background.js
@@ -5,7 +5,7 @@ chrome.runtime.onMessageExternal.addListener(function(request, sender, sendRespo
 	chrome.cookies.getAll({}, function(cookies) {
 		for (var i in cookies) {
 			var cookie = cookies[i];
-			if (cookie.domain == "bibliotik.me" && cookie.name == "id") {
+			if (cookie.domain == ".bibliotik.me" && cookie.name == "id") {
 				sendResponse(cookie.value);
 				return;
 			}

--- a/templates/userscript/bibliotik.user.js
+++ b/templates/userscript/bibliotik.user.js
@@ -53,7 +53,7 @@ function stealBibliotikSessionId(callback) {
             text: 'Please make sure the extension is installed and working.',
             type: 'error'
         });
-    }, 1000);
+    }, 1500);
     chrome.runtime.sendMessage(extensionId, "stealBibliotikId", function (response) {
         clearTimeout(timeoutID);
         if (response == null) {
@@ -144,7 +144,7 @@ function processResult(result) {
         row.actions.empty();
         if (resp.status == 'downloaded') {
             // Download
-            link = $('<a href="' + downloadUrl + resp.id + '">↓</a>');
+            link = $('<a href="' + downloadUrl + resp.id + '">↓DL</a>');
             row.actions.append(link);
         } else if (resp.status == 'downloading') {
             row.actions.text(Math.floor(resp.progress * 100) + '%');

--- a/templates/userscript/bibliotik.user.js
+++ b/templates/userscript/bibliotik.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name Bibliotik.me / WM Integrator
 // @namespace https://karamanolev.com
-// @version 0.2.1
+// @version 0.2.2
 // @description Integration between WM and Bibliotik.me
 // @match http://bibliotik.me/*
 // @match https://bibliotik.me/*
@@ -124,7 +124,7 @@ function downloadTorrent(row) {
             row.actions.text('ERR');
         } else {
             noty({
-                text: 'Error adding ' + resp.id + ': ' + addResult.error,
+                text: 'Error adding ' + row.whatId + ': ' + addResult.error,
                 type: 'error'
             });
             row.actions.text('ERR');


### PR DESCRIPTION
Bibliotik changed the domain for its cookies from "bibliotik.me" to ".bibliotik.me", which broke the Chrome extension. 

~~I'm not sure what else they changed (seeing as I could successfully add torrents 5 days ago), but when I try to add a torrent now with the corrected extension, my WhatManager2 instance shows this error:~~

~~"Tried adding bibliotik torrent_id=253348. Error: list index out of range"~~