### PR TITLE
Use default time module rather than samba.netcmd

### DIFF
--- a/myanonamouse/utils.py
+++ b/myanonamouse/utils.py
@@ -1,7 +1,7 @@
 import re
 import requests
 import pickle
-from samba.netcmd import time
+import time
 
 from myanonamouse.models import MAMLoginCache
 from myanonamouse.settings import MAM_USERNAME, MAM_PASSWORD, MAM_LOGIN_URL, MAM_ROOT_URL


### PR DESCRIPTION
I believe this should fix the issue where this module can't be found, without affecting functionality...