### PR TITLE
Universal source string support

### DIFF
--- a/WhatManager2/settings.example.py
+++ b/WhatManager2/settings.example.py
@@ -19,8 +19,9 @@ SYNC_SYNCS_FILES = False
 # You might set this to ssl.passtheheadphones.me if PTH has a long downtime, but ssl is up.
 WHAT_CD_DOMAIN = 'passtheheadphones.me'
 WHAT_UPLOAD_URL = 'https://{0}/upload.php'.format(WHAT_CD_DOMAIN)
-# Only for uploading
+# Only for uploading, leave source string blank if your tracker does not use this fuction
 WHAT_ANNOUNCE = 'http://please.passtheheadphones.me/SET THIS TO YOUR ANNOUNCE/announce'
+SOURCE_STRING = 'PTH'
 
 # Set this to something reasonable that only you know.
 TRANSMISSION_PASSWORD = '9dqQQ2WW'


### PR DESCRIPTION
Allows you to specify other source strings in settings or disable
source string entirely. Also adds a check to handle a rare exception in which the response returned from the tracker is not in json format.