### PR TITLE
Add an option to use systemd for transmission-daemon instances

### DIFF
--- a/WhatManager2/management/commands/transmission_new.py
+++ b/WhatManager2/management/commands/transmission_new.py
@@ -45,7 +45,8 @@ class Command(BaseCommand):
                                      .replace('.cd', '')
                                      .replace('.org', '')
                                      .replace('.net', '')
-                                     .replace('.me', '')),
+                                     .replace('.me', '')
+                                     .replace('.ch', '')),
                 host='127.0.0.1',
                 port=zero_port,
                 peer_port=zero_peer_port,

--- a/WhatManager2/management/commands/transmission_provision.py
+++ b/WhatManager2/management/commands/transmission_provision.py
@@ -280,9 +280,9 @@ class TransInstanceManager(object):
             confirm()
             os.chmod(self.init_path, self.init_script_perms)
         if use_systemd():
-           print 'Enabling systemd unit for {0}'.format(self.name)
-           confirm()
-           subprocess.call(['systemctl', 'enable', self.service_name])
+            print 'Enabling systemd unit for {0}'.format(self.name)
+            confirm()
+            subprocess.call(['systemctl', 'enable', self.service_name])
         if not user_exists(self.username):
             print 'Creating user {0} for {1}'.format(self.username, self.name)
             confirm()

--- a/WhatManager2/management/commands/transmission_provision.py
+++ b/WhatManager2/management/commands/transmission_provision.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python
-from optparse import make_option
+import json
 import os
 import os.path
 import pwd
 import subprocess
-import json
-
+from WhatManager2.settings import TRANSMISSION_FILES_ROOT, TRANSMISSION_BIND_HOST, TRANSMISSION_USE_SYSTEMD
 from django.core.management.base import BaseCommand, CommandError
+from optparse import make_option
 
-from WhatManager2.settings import TRANSMISSION_FILES_ROOT, TRANSMISSION_BIND_HOST
 from WhatManager2.utils import read_text, write_text
 from home import models
-
 
 transmission_init_script_template = '''#!/bin/sh -e
 ### BEGIN INIT INFO
@@ -81,6 +79,19 @@ esac
 
 exit 0
 '''
+transmission_init_script_template_systemd = '''[Unit]
+Description=transmission-daemon-<<<name>>>
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=/sbin/start-stop-daemon --start --chuid transmission-<<<name>>> --user transmission-<<<name>>> \
+--exec <<<daemon_path>>> -- -g <<<files_path>>>
+ExecStop=/sbin/start-stop-daemon --quiet --stop --user transmission-<<<name>>> \
+--exec <<<daemon_path>>> --retry 30 --oknodo
+
+[Install]
+WantedBy=multi-user.target'''
 
 
 def discover_transmission():
@@ -93,7 +104,7 @@ def discover_transmission():
 
 def get_transmission_init_script(name, files_path):
     return (
-        transmission_init_script_template
+        (transmission_init_script_template_systemd if TRANSMISSION_USE_SYSTEMD else transmission_init_script_template)
         .replace('<<<daemon_path>>>', discover_transmission())
         .replace('<<<files_path>>>', files_path)
         .replace('<<<name>>>', name)
@@ -229,9 +240,12 @@ class TransInstanceManager(object):
         self.name = str(instance.name)
         self.service_name = 'transmission-daemon-{0}'.format(self.name)
         self.transmission_files_path = os.path.join(TRANSMISSION_FILES_ROOT, self.name)
-        self.init_path = os.path.join('/etc/init.d', self.service_name)
+        if TRANSMISSION_USE_SYSTEMD:
+            self.init_path = os.path.join('/lib/systemd/system', self.service_name + '.service')
+        else:
+            self.init_path = os.path.join('/etc/init.d', self.service_name)
         self.init_script = get_transmission_init_script(self.name, self.transmission_files_path)
-        self.init_script_perms = 0755
+        self.init_script_perms = 0644 if TRANSMISSION_USE_SYSTEMD else 0755
         self.username = 'transmission-{0}'.format(self.name)
         self.settings_path = os.path.join(self.transmission_files_path, 'settings.json')
         self.settings_json = get_transmission_settings(
@@ -247,7 +261,8 @@ class TransInstanceManager(object):
 
     def sync(self):
         if not os.path.isfile(self.init_path):
-            print 'Creating init script for {0}'.format(self.name)
+            print 'Creating {0} file for {1}'.format('systemd unit' if TRANSMISSION_USE_SYSTEMD else 'Upstart job',
+                                                     self.name)
             confirm()
             self.write_init_script()
         if self.init_script != read_text(self.init_path):
@@ -258,6 +273,10 @@ class TransInstanceManager(object):
             print 'Fixing init script permissions for {0}'.format(self.name)
             confirm()
             os.chmod(self.init_path, self.init_script_perms)
+        if TRANSMISSION_USE_SYSTEMD:
+           print 'Enabling systemd unit for {0}'.format(self.name)
+           confirm()
+           subprocess.call(['systemctl', 'enable', self.service_name])
         if not user_exists(self.username):
             print 'Creating user {0} for {1}'.format(self.username, self.name)
             confirm()
@@ -277,7 +296,11 @@ class TransInstanceManager(object):
             self.write_settings()
 
     def exec_init_script(self, action):
-        args = ['service', self.service_name, action]
+        if TRANSMISSION_USE_SYSTEMD:
+            args = ['systemctl', action, self.service_name]
+        else:
+            args = ['service', self.service_name, action]
+
         if subprocess.call(args) != 0:
             print 'Warning! Service start returned non-zero. args={0}'.format(args)
 

--- a/WhatManager2/management/commands/transmission_provision.py
+++ b/WhatManager2/management/commands/transmission_provision.py
@@ -105,7 +105,7 @@ def discover_transmission():
 
 def use_systemd():
     # Use getattr rather than importing the setting, to avoid an error if the setting is non-existent
-    return getattr(settings, 'TRANSMISSION_USE_SYSTEMD', False)
+    return getattr(WhatManager2.settings, 'TRANSMISSION_USE_SYSTEMD', False)
 
 
 def get_transmission_init_script(name, files_path):

--- a/WhatManager2/settings.example.py
+++ b/WhatManager2/settings.example.py
@@ -28,6 +28,8 @@ TRANSMISSION_PASSWORD = '9dqQQ2WW'
 TRANSMISSION_FILES_ROOT = '/mnt/tank/Torrent/transmission-daemon'
 # Transmission's ipv4 bind address. Leave as is or changed to specific ip.
 TRANSMISSION_BIND_HOST = '0.0.0.0'
+# Set this to true to use systemd rather than Upstart for Transmission daemon instances
+TRANSMISSION_USE_SYSTEMD = False
 
 # You only need these if you are uploading books
 WHATIMG_USERNAME = 'whatimg username'


### PR DESCRIPTION
There is a new flag in the settings which will enable this; otherwise, Upstart is used.

This should mean that existing users will not be affected and any new users who wish to use Upstart can do so. But for those on fresh Ubuntu 16.04 installs, for example, where systemd is the default init system, there's now an option to use that.