### PR TITLE
Add a check for 2FA when logging in. Return a useful error if it's enabled.

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -674,7 +674,10 @@ class CustomWhatAPI:
             }
             r = self.session.post(loginpage, data=data, allow_redirects=False)
             if r.status_code != 302:
-                raise LoginException
+                if '<form class="auth_form" name="2fa" id="2fa"' in r.text:
+                    raise LoginException("2FA is enabled on your account, unable to login.")
+                else:
+                    raise LoginException
             accountinfo = self.request("index")
             self.authkey = accountinfo["response"]["authkey"]
             self.passkey = accountinfo["response"]["passkey"]

--- a/home/models.py
+++ b/home/models.py
@@ -677,7 +677,7 @@ class CustomWhatAPI:
                 if '<form class="auth_form" name="2fa" id="2fa"' in r.text:
                     raise LoginException("2FA is enabled on your account, unable to login.")
                 else:
-                    raise LoginException
+                    raise LoginException("Unsuccessful login attempt.")
             accountinfo = self.request("index")
             self.authkey = accountinfo["response"]["authkey"]
             self.passkey = accountinfo["response"]["passkey"]


### PR DESCRIPTION
RED recently introduced 2FA, but of course WM2 can't handle this (yet... although it would be a little complicated, I suspect).

I added a check in CustomWhatAPI._login() for the 2FA form HTML in the response and returned a relevant message in the exception.

I also added a generic message if the login fails for any reason. Since this message propagates all the way up to the front page / Log page, an empty error isn't very helpful.

