### PR TITLE
Add a management command to delete transmission instances

### DIFF
--- a/WhatManager2/management/commands/transmission_delete.py
+++ b/WhatManager2/management/commands/transmission_delete.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+from django.core.management.base import BaseCommand, CommandError
+
+from WhatManager2.management.commands.transmission_provision import confirm, TransInstanceManager, ensure_root
+from home.models import TransInstance
+
+
+class Command(BaseCommand):
+    help = u'Removes existing Transmission instances'
+
+    def add_arguments(self, parser):
+        parser.add_argument('name', nargs='+')
+
+    def handle(self, *args, **options):
+        ensure_root()
+        for name in options['name']:
+            try:
+                instance = TransInstance.objects.get(name=name)
+            except TransInstance.DoesNotExist:
+                raise CommandError('TransInstance "%s" does not exist' % name)
+
+            if instance.torrent_count > 0:
+                # Don't allow instances with torrents to be deleted for now. Would be more complicated, destructive and
+                # less likely for users to want to do so anyway.
+                self.stdout.write(self.style.WARNING(u'Will not delete "%s", as it contains torrents' % instance.name))
+                return
+
+            print u'Deleting TransInstance %s...' % instance.name
+            self.stdout.write(self.style.NOTICE('This will remove the daemon, all related files, and the user.'))
+            confirm()
+
+            manager = TransInstanceManager(instance)
+            manager.remove()
+
+            instance.delete()
+
+            # BaseCommand.style.SUCCESS was only added in Django 1.9
+            if hasattr(self.style, 'SUCCESS'):
+                self.stdout.write(self.style.SUCCESS(u'Successfully deleted "%s"' % instance.name))
+            else:
+                self.stdout.write(self.style.WARNING(u'Successfully deleted "%s"' % instance.name))


### PR DESCRIPTION
Currently this only allows instances to be deleted if they do not contain any torrents. It will reverse everything done by transmission_new: stop and disable the daemon; delete the init file, transmission files (settings, resume, stats etc.), dedicated user account, and database object.