### PR TITLE
Make userscripts Greasemonkey 4 compatible

### DIFF
--- a/templates/userscript/bibliotik.user.js
+++ b/templates/userscript/bibliotik.user.js
@@ -6,6 +6,7 @@
 // @match http://bibliotik.me/*
 // @match https://bibliotik.me/*
 // @grant GM.xmlHttpRequest
+// @grant GM_xmlhttpRequest
 // @updateURL {{ root }}/userscript/bibliotik.user.js
 // @require https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js
 // @require {{ root }}/static/js/jquery.noty.packaged.min.js

--- a/templates/userscript/bibliotik.user.js
+++ b/templates/userscript/bibliotik.user.js
@@ -1,14 +1,15 @@
 // ==UserScript==
 // @name Bibliotik.me / WM Integrator
 // @namespace https://karamanolev.com
-// @version 0.2.4
+// @version 0.2.5
 // @description Integration between WM and Bibliotik.me
 // @match http://bibliotik.me/*
 // @match https://bibliotik.me/*
-// @grant GM_xmlhttpRequest
+// @grant GM.xmlHttpRequest
 // @updateURL {{ root }}/userscript/bibliotik.user.js
 // @require https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js
 // @require {{ root }}/static/js/jquery.noty.packaged.min.js
+// @require https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js
 // ==/UserScript==
 
 var torrentsInfoUrl = '{{ root }}/books/bibliotik/json/torrents_info';
@@ -30,7 +31,7 @@ function submitIds(rows, callback) {
         var ids = [];
         for (var i in rows) ids.push(rows[i].whatId);
         var idsString = 'ids=' + encodeURIComponent(ids.join(','));
-        GM_xmlhttpRequest({
+        GM.xmlHttpRequest({
             method: "GET",
             url: torrentsInfoUrl + '?' + idsString,
             onload: function (response) {
@@ -70,7 +71,7 @@ function addTorrent(torrentId, callback) {
     stealBibliotikSessionId(function (sessionId) {
         var params = encodeURIComponent(torrentId) + '?';
         params += 'bibliotik_id=' + encodeURIComponent(sessionId);
-        GM_xmlhttpRequest({
+        GM.xmlHttpRequest({
             method: "GET",
             url: addTorrentUrl + params,
             onload: function (response) {

--- a/templates/userscript/myanonamouse.user.js
+++ b/templates/userscript/myanonamouse.user.js
@@ -6,6 +6,7 @@
 // @match http://*.myanonamouse.net/*
 // @match https://*.myanonamouse.net/*
 // @grant GM.xmlHttpRequest
+// @grant GM_xmlhttpRequest
 // @updateURL {{ root }}/userscript/bibliotik.user.js
 // @require https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js
 // @require {{ root }}/static/js/jquery.noty.packaged.min.js

--- a/templates/userscript/myanonamouse.user.js
+++ b/templates/userscript/myanonamouse.user.js
@@ -1,14 +1,15 @@
 // ==UserScript==
 // @name MyAnonaMouse / WM Integrator
 // @namespace https://karamanolev.com
-// @version 0.1.1
+// @version 0.1.2
 // @description Integration between WM and MyAnonaMouse.net
 // @match http://*.myanonamouse.net/*
 // @match https://*.myanonamouse.net/*
-// @grant GM_xmlhttpRequest
+// @grant GM.xmlHttpRequest
 // @updateURL {{ root }}/userscript/bibliotik.user.js
 // @require https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js
 // @require {{ root }}/static/js/jquery.noty.packaged.min.js
+// @require https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js
 // ==/UserScript==
 
 var torrentsInfoUrl = '{{ root }}/myanonamouse/json/torrents_info';
@@ -31,7 +32,7 @@ function submitIds(rows, callback) {
             ids.push(row.whatId);
         });
         var idsString = 'ids=' + encodeURIComponent(ids.join(','));
-        GM_xmlhttpRequest({
+        GM.xmlHttpRequest({
             method: "GET",
             url: torrentsInfoUrl + '?' + idsString,
             onload: function (response) {
@@ -50,7 +51,7 @@ function submitIds(rows, callback) {
 
 function addTorrent(torrentId, callback) {
     var params = encodeURIComponent(torrentId);
-    GM_xmlhttpRequest({
+    GM.xmlHttpRequest({
         method: "GET",
         url: addTorrentUrl + params,
         onload: function (response) {

--- a/templates/userscript/overdrive.user.js
+++ b/templates/userscript/overdrive.user.js
@@ -1,13 +1,14 @@
 // ==UserScript==
 // @name OverDrive Tracker Search
 // @namespace https://karamanolev.com
-// @version 0.0.3
+// @version 0.0.4
 // @description Integration between OverDrive and torrent trackers
 // @match http://localhost/*
 // @match http://*.overdrive.com/*
-// @grant GM_xmlhttpRequest
+// @grant GM.xmlHttpRequest
 // @updateURL {{ root }}/userscript/overdrive.user.js
 // @require http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js
+// @require https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js
 // ==/UserScript==
 
 var bibliotikSearchProxyUrl = '{{ root }}/books/bibliotik/json/search';
@@ -77,7 +78,7 @@ function detailsWindowMaker($this) {
 }
 
 function whatSearchHandler(query, callback) {
-    GM_xmlhttpRequest({
+    GM.xmlHttpRequest({
         method: 'GET',
         url: whatSearchProxyUrl + '?action=browse&filter_cat%5B3%5D=1&searchstr=' + encodeURIComponent(query),
         onload: function (response) {
@@ -108,7 +109,7 @@ function bibliotikSearchHandler(query, callback) {
         var url = bibliotikSearchProxyUrl;
         url += '?query=' + encodeURIComponent(query);
         url += '&bibliotik_id=' + encodeURIComponent(sessionId);
-        GM_xmlhttpRequest({
+        GM.xmlHttpRequest({
             method: 'GET',
             url: url,
             onload: function (response) {

--- a/templates/userscript/overdrive.user.js
+++ b/templates/userscript/overdrive.user.js
@@ -6,6 +6,7 @@
 // @match http://localhost/*
 // @match http://*.overdrive.com/*
 // @grant GM.xmlHttpRequest
+// @grant GM_xmlhttpRequest
 // @updateURL {{ root }}/userscript/overdrive.user.js
 // @require http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js
 // @require https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js

--- a/templates/userscript/what.cd.user.js
+++ b/templates/userscript/what.cd.user.js
@@ -1,13 +1,14 @@
 // ==UserScript==
 // @name What.CD / WM Integrator
 // @namespace https://karamanolev.com
-// @version 1.2.2
+// @version 1.2.3
 // @description Integration between WM and What.CD
 // @match https://redacted.ch/*
-// @grant GM_xmlhttpRequest
+// @grant GM.xmlHttpRequest
 // @updateURL {{ root }}/userscript/what.cd.user.js
 // @require https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js
 // @require {{ root }}/static/js/jquery.noty.packaged.min.js
+// @require https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js
 // ==/UserScript==
 
 var torrentsInfoUrl = '{{ root }}/json/torrents_info';
@@ -29,7 +30,7 @@ function submitIds(rows, callback) {
         var ids = [];
         for (var i in rows) ids.push(rows[i].whatId);
 
-        GM_xmlhttpRequest({
+        GM.xmlHttpRequest({
             method: "POST",
             url: torrentsInfoUrl,
             data: "ids=" + ids.join(','),
@@ -52,7 +53,7 @@ function submitIds(rows, callback) {
 
 function addTorrent(whatId, callback) {
     setTimeout(function () {
-        GM_xmlhttpRequest({
+        GM.xmlHttpRequest({
             method: "POST",
             url: addTorrentUrl,
             data: 'id=' + whatId,
@@ -74,7 +75,7 @@ function addTorrent(whatId, callback) {
 
 function addTranscodeRequest(whatId, callback) {
     setTimeout(function () {
-        GM_xmlhttpRequest({
+        GM.xmlHttpRequest({
             method: "POST",
             url: transcodeRequestUrl,
             data: 'what_id=' + whatId,

--- a/templates/userscript/what.cd.user.js
+++ b/templates/userscript/what.cd.user.js
@@ -5,6 +5,7 @@
 // @description Integration between WM and What.CD
 // @match https://redacted.ch/*
 // @grant GM.xmlHttpRequest
+// @grant GM_xmlhttpRequest
 // @updateURL {{ root }}/userscript/what.cd.user.js
 // @require https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js
 // @require {{ root }}/static/js/jquery.noty.packaged.min.js


### PR DESCRIPTION
There have been some API changes with the recently released Greasemonkey 4:
https://www.greasespot.net/2017/09/greasemonkey-4-for-script-authors.html

These changes broke the scripts. I fixed them while maintaining backward compatibility.

Tested using:

- Firefox 57.0
  - Greasemonkey 4.0
  - Tampermonkey 4.5.5590